### PR TITLE
Spyke dependency change

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,17 +1,17 @@
 PATH
   remote: .
   specs:
-    spyke-kaminari (0.0.4)
+    spyke-kaminari (0.0.5)
       activesupport (~> 4)
-      spyke (~> 3.1)
+      spyke (>= 3.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (4.2.1)
-      activesupport (= 4.2.1)
+    activemodel (4.2.5)
+      activesupport (= 4.2.5)
       builder (~> 3.1)
-    activesupport (4.2.1)
+    activesupport (4.2.5)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
@@ -23,14 +23,14 @@ GEM
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
-    faraday (0.9.1)
+    faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
-    faraday_middleware (0.9.1)
+    faraday_middleware (0.10.0)
       faraday (>= 0.7.4, < 0.10)
     i18n (0.7.0)
-    json (1.8.2)
+    json (1.8.3)
     method_source (0.8.2)
-    minitest (5.5.1)
+    minitest (5.8.3)
     multipart-post (2.0.0)
     pry (0.10.1)
       coderay (~> 1.1.0)
@@ -50,10 +50,10 @@ GEM
     rspec-support (3.1.2)
     safe_yaml (1.0.4)
     slop (3.6.0)
-    spyke (3.1.0)
+    spyke (4.0.1)
       activemodel (>= 3.0.0, < 5.0)
       activesupport (>= 3.0.0, < 5.0)
-      faraday (>= 0.8.0, < 2.0)
+      faraday (>= 0.9.0, < 2.0)
       faraday_middleware (>= 0.9.1, < 2.0)
       uri_template (>= 0.7.0, < 2.0)
     thread_safe (0.3.5)
@@ -72,3 +72,6 @@ DEPENDENCIES
   rspec (= 3.1.0)
   spyke-kaminari!
   webmock (~> 1.20)
+
+BUNDLED WITH
+   1.10.6

--- a/spyke-kaminari.gemspec
+++ b/spyke-kaminari.gemspec
@@ -1,11 +1,11 @@
-Gem::Specification.new('spyke-kaminari', '0.0.4') do |spec|
+Gem::Specification.new('spyke-kaminari', '0.0.5') do |spec|
   spec.authors  = ['Todd Mazierski']
   spec.email    = ['todd@generalassemb.ly']
   spec.homepage = 'https://github.com/generalassembly/spyke-kaminari'
   spec.summary  = 'Kaminari pagination for Spyke models'
   spec.files    =  Dir['lib/**/*']
 
-  spec.add_runtime_dependency 'spyke', '~>  3.1'
+  spec.add_runtime_dependency 'spyke', '>= 3.1'
   spec.add_runtime_dependency 'activesupport', '~> 4'
 
   spec.add_development_dependency 'rspec', '3.1.0'


### PR DESCRIPTION
## Summary
Loosen `spyke` dependency to allow `>= 3.1` versions, since this currently locks all our clients to the `3.1` branch, meaning we can't use `4.0.0` of `spyke` or higher.